### PR TITLE
Bump web3py version to 6.13.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,9 @@ setup(
     author='SKALE Labs',
     author_email='support@skalelabs.com',
     install_requires=[
-      'web3==6.3.0',
+      'web3==6.13.0',
       'pyzmq==25.0.2',
       'pem==21.2.0',
-      'M2Crypto==0.38.0',
       'urllib3==1.26.0'
     ],
     packages=find_packages(exclude=['tests']),

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
       'web3==6.13.0',
       'pyzmq==25.0.2',
       'pem==21.2.0',
+      'M2Crypto==0.40.1',
       'urllib3==1.26.0'
     ],
     packages=find_packages(exclude=['tests']),


### PR DESCRIPTION
This PR updates 2 dependencies to the latest versions.
No additional tests needed.
No performance changes.

Resolves https://github.com/skalenetwork/skale-admin/issues/832