### PR TITLE
Update dependencies, drop M2Crypto, update to python3.13

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 100
-exclude = .git,__pycache__,venv

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,10 @@ jobs:
       PIP_PASSWORD: ${{ secrets.PIP_PASSWORD }}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.11
+    - name: Set up Python 3.13
       uses: actions/setup-python@v1
       with:
-        python-version: 3.11
+        python-version: 3.13
     - name: Install python dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,9 @@ jobs:
         sudo apt-get install python3-dev
         pip install -e .
         pip install -e .[dev]
-    - name: Lint with flake8
+    - name: Lint with ruff
       run: |
-        flake8 .
+        ruff check sgx/ tests/
     - name: Run containers
       run: |
         export SGX_WALLET_TAG=1.83.0-develop.12
@@ -67,9 +67,6 @@ jobs:
         sudo apt-get install python3-dev
         pip install -e .
         pip install -e .[dev]
-    - name: Lint with flake8
-      run: |
-        flake8 .
     - name: Run containers
       run: |
         export SGX_WALLET_TAG=1.83.0-develop.12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
       ETH_PRIVATE_KEY: ${{ secrets.ETH_PRIVATE_KEY }}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.11
+    - name: Set up Python 3.13
       uses: actions/setup-python@v1
       with:
-        python-version: 3.11
+        python-version: 3.13
     - name: Install python dependencies
       run: |
         sudo apt-get update --fix-missing
@@ -54,10 +54,10 @@ jobs:
       TEST_ACCOUNT: ${{ secrets.TEST_ACCOUNT }}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.11
+    - name: Set up Python 3.13
       uses: actions/setup-python@v1
       with:
-        python-version: 3.11
+        python-version: 3.13
     - name: Install python dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Test
 on:
   push:
     branches-ignore:
-      - 'develop'
-      - 'master'
-      - 'beta'
-      - 'stable'
+      - "develop"
+      - "master"
+      - "beta"
+      - "stable"
 
 jobs:
   test_core:
@@ -17,34 +17,34 @@ jobs:
       TEST_ACCOUNT: ${{ secrets.TEST_ACCOUNT }}
       ETH_PRIVATE_KEY: ${{ secrets.ETH_PRIVATE_KEY }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.13
-    - name: Install python dependencies
-      run: |
-        sudo apt-get update --fix-missing
-        sudo apt-get install libudev-dev
-        sudo apt-get install swig
-        sudo apt-get install python3-dev
-        pip install -e .
-        pip install -e .[dev]
-    - name: Lint with ruff
-      run: |
-        ruff check sgx/ tests/
-    - name: Run containers
-      run: |
-        export SGX_WALLET_TAG=1.83.0-develop.12
-        bash scripts/run_sgx_simulator.sh
-        mkdir $CERT_PATH
-        docker run -d -p 8545:8545 --name ganache trufflesuite/ganache:beta --account="0x${{ secrets.ETH_PRIVATE_KEY }},100000000000000000000000000" -l 80000000 -b 0.01
-        sleep 60
-        docker ps -a 
-        docker logs ganache --tail 500
-    - name: Run tests
-      run: |
-        py.test tests/ --ignore tests/test_dkg.py
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.13
+      - name: Install python dependencies
+        run: |
+          sudo apt-get update --fix-missing
+          sudo apt-get install libudev-dev
+          sudo apt-get install swig
+          sudo apt-get install python3-dev
+          pip install -e .
+          pip install -e .[dev]
+      - name: Lint with ruff
+        run: |
+          ruff check sgx/ tests/
+      - name: Run containers
+        run: |
+          export SGX_WALLET_TAG=1.10.1-develop.4
+          bash scripts/run_sgx_simulator.sh
+          mkdir $CERT_PATH
+          docker run -d -p 8545:8545 --name ganache trufflesuite/ganache:beta --account="0x${{ secrets.ETH_PRIVATE_KEY }},100000000000000000000000000" -l 80000000 -b 0.01
+          sleep 60
+          docker ps -a 
+          docker logs ganache --tail 500
+      - name: Run tests
+        run: |
+          py.test tests/ --ignore tests/test_dkg.py
   test_dkg:
     runs-on: ubuntu-22.04
     env:
@@ -53,26 +53,26 @@ jobs:
       SERVER: ${{ secrets.SERVER }}
       TEST_ACCOUNT: ${{ secrets.TEST_ACCOUNT }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.13
-    - name: Install python dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install libudev-dev
-        sudo apt-get install libusb-1.0-0-dev
-        sudo apt-get install swig
-        sudo apt-get install python3-dev
-        pip install -e .
-        pip install -e .[dev]
-    - name: Run containers
-      run: |
-        export SGX_WALLET_TAG=1.83.0-develop.12
-        bash scripts/run_sgx_simulator.sh
-        mkdir $CERT_PATH
-        sleep 60
-    - name: Run tests
-      run: |
-        pytest ./tests/test_dkg.py
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.13
+      - name: Install python dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libudev-dev
+          sudo apt-get install libusb-1.0-0-dev
+          sudo apt-get install swig
+          sudo apt-get install python3-dev
+          pip install -e .
+          pip install -e .[dev]
+      - name: Run containers
+        run: |
+          export SGX_WALLET_TAG=1.10.1-develop.4
+          bash scripts/run_sgx_simulator.sh
+          mkdir $CERT_PATH
+          sleep 60
+      - name: Run tests
+        run: |
+          pytest ./tests/test_dkg.py

--- a/scripts/run_sgx_simulator.sh
+++ b/scripts/run_sgx_simulator.sh
@@ -10,3 +10,10 @@ SGX_WALLET_CONTAINER_NAME=sgx_simulator
 docker rm -f $SGX_WALLET_CONTAINER_NAME || true
 docker pull $SGX_WALLET_IMAGE_NAME
 docker run -d -p 1026-1031:1026-1031 --name $SGX_WALLET_CONTAINER_NAME $SGX_WALLET_IMAGE_NAME -s -y
+
+sleep 30
+
+echo "==============================="
+echo "SGX simulator logs:"
+docker logs $SGX_WALLET_CONTAINER_NAME
+echo "==============================="

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,9 @@ setup(
     author_email='support@skalelabs.com',
     install_requires=[
         'web3>=6.20.2,<8.0.0',
-        'pyzmq==26.4.0',
-        'pem==21.2.0',
-        'M2Crypto>=0.40.1,<1.0.0',
-        'urllib3==1.26.0',
+        'pyzmq==27.1.0',
+        'pem==23.1.0',
+        'cryptography>=41.0.0,<44.0.0',
     ],
     packages=find_packages(exclude=['tests']),
     python_requires='>=3.7,<4',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'web3>=6.20.2,<8.0.0',
         'pyzmq==27.1.0',
         'pem==23.1.0',
-        'cryptography>=41.0.0,<44.0.0',
+        'cryptography>=46.0.1,<47.0.0',
     ],
     packages=find_packages(exclude=['tests']),
     python_requires='>=3.7,<4',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import (
 
 extras_require = {
     'linter': [
-        'flake8==3.8.3',
+        'ruff==0.13.2',
     ],
     'dev': [
         'coincurve==13.0.0',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'cryptography>=46.0.1,<47.0.0',
     ],
     packages=find_packages(exclude=['tests']),
-    python_requires='>=3.7,<4',
+    python_requires='>=3.11,<4',
     extras_require=extras_require,
     package_data={'sgx': ['generate.sh']},
 )

--- a/sgx/sgx_zmq.py
+++ b/sgx/sgx_zmq.py
@@ -32,7 +32,6 @@ import zmq
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, rsa, padding
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
-from cryptography.hazmat.backends import default_backend
 
 from urllib.parse import urlparse
 
@@ -296,9 +295,7 @@ class SgxZmq:
         key_path = os.path.join(self.path_to_cert, KEY_FILENAME)
         with open(key_path, 'rb') as key_file:
             private_key_bytes = key_file.read()
-        private_key = load_pem_private_key(
-            private_key_bytes, password=None, backend=default_backend()
-        )
+        private_key = load_pem_private_key(private_key_bytes, password=None)
         data = msg.encode()
         if isinstance(private_key, ec.EllipticCurvePrivateKey):
             signature = private_key.sign(data, ec.ECDSA(hashes.SHA256()))

--- a/sgx/sgx_zmq.py
+++ b/sgx/sgx_zmq.py
@@ -30,7 +30,7 @@ from eth_utils.conversions import add_0x_prefix, remove_0x_prefix
 import pem
 import zmq
 from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric import ec, rsa, padding
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.hazmat.backends import default_backend
 
@@ -299,7 +299,13 @@ class SgxZmq:
         private_key = load_pem_private_key(
             private_key_bytes, password=None, backend=default_backend()
         )
-        signature = private_key.sign(msg.encode(), ec.ECDSA(hashes.SHA256()))
+        data = msg.encode()
+        if isinstance(private_key, ec.EllipticCurvePrivateKey):
+            signature = private_key.sign(data, ec.ECDSA(hashes.SHA256()))
+        elif isinstance(private_key, rsa.RSAPrivateKey):
+            signature = private_key.sign(data, padding.PKCS1v15(), hashes.SHA256())
+        else:
+            raise TypeError('Unsupported private key type for signing')
         return binascii.hexlify(signature).decode()
 
     def __read_cert(self):

--- a/sgx/sgx_zmq.py
+++ b/sgx/sgx_zmq.py
@@ -29,16 +29,14 @@ from sgx.utils import public_key_to_address
 from eth_utils.conversions import add_0x_prefix, remove_0x_prefix
 import pem
 import zmq
-from M2Crypto import EVP
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.hazmat.backends import default_backend
 
 from urllib.parse import urlparse
 
-from sgx.constants import (
-    DEFAULT_TIMEOUT,
-    SGX_ZMQ_RESPONSE_TIMEOUT_MS,
-    CRT_FILENAME,
-    KEY_FILENAME
-)
+from sgx.constants import DEFAULT_TIMEOUT, SGX_ZMQ_RESPONSE_TIMEOUT_MS, CRT_FILENAME, KEY_FILENAME
 from sgx.utils import SgxError
 
 
@@ -107,21 +105,17 @@ class SgxZmq:
 
     def generate_key(self):
         params = dict()
-        response = self.__send_request("generateECDSAKey", params)
+        response = self.__send_request('generateECDSAKey', params)
         key_name = response['keyName']
         public_key = response['publicKey']
         public_key = add_0x_prefix(public_key)
         address = public_key_to_address(public_key)
-        return Account(
-            name=key_name,
-            address=address,
-            public_key=public_key
-        )
+        return Account(name=key_name, address=address, public_key=public_key)
 
     def get_public_key(self, keyName):
         params = dict()
         params['keyName'] = keyName
-        response = self.__send_request("getPublicECDSAKey", params)
+        response = self.__send_request('getPublicECDSAKey', params)
         publicKey = response['publicKey']
         return publicKey
 
@@ -131,7 +125,7 @@ class SgxZmq:
         params = dict()
         params['polyName'] = poly_name
         params['t'] = self.t
-        response = self.__send_request("generateDKGPoly", params)
+        response = self.__send_request('generateDKGPoly', params)
         if response['status'] == 0:
             return DkgPolyStatus.NEW_GENERATED
         else:
@@ -142,7 +136,7 @@ class SgxZmq:
         params['polyName'] = poly_name
         params['n'] = self.n
         params['t'] = self.t
-        response = self.__send_request("getVerificationVector", params)
+        response = self.__send_request('getVerificationVector', params)
         verification_vector = response['verificationVector']
         return verification_vector
 
@@ -153,16 +147,16 @@ class SgxZmq:
         params['n'] = self.n
         params['t'] = self.t
         params['publicKeys'] = public_keys
-        response = self.__send_request("getSecretShare", params)
+        response = self.__send_request('getSecretShare', params)
         secret_key_contribution = response['secretShare']
         return secret_key_contribution
 
     def get_server_status(self):
-        response = self.__send_request("getServerStatus")
+        response = self.__send_request('getServerStatus')
         return response['status']
 
     def get_server_version(self):
-        response = self.__send_request("getServerVersion")
+        response = self.__send_request('getServerVersion')
         return response['version']
 
     def verify_secret_share(self, public_shares, eth_key_name, secret_share, index):
@@ -173,7 +167,7 @@ class SgxZmq:
         params['n'] = self.n
         params['t'] = self.t
         params['index'] = index
-        response = self.__send_request("dkgVerification", params)
+        response = self.__send_request('dkgVerification', params)
         result = response['result']
         return result
 
@@ -185,13 +179,13 @@ class SgxZmq:
         params['secretShare'] = secret_shares
         params['n'] = self.n
         params['t'] = self.t
-        response = self.__send_request("createBLSPrivateKey", params)
+        response = self.__send_request('createBLSPrivateKey', params)
         return response['status'] == 0
 
     def get_bls_public_key(self, bls_key_name):
         params = dict()
-        params["blsKeyName"] = bls_key_name
-        response = self.__send_request("getBLSPublicKeyShare", params)
+        params['blsKeyName'] = bls_key_name
+        response = self.__send_request('getBLSPublicKeyShare', params)
         return response['blsPublicKeyShare']
 
     def complaint_response(self, poly_name, idx):
@@ -200,39 +194,39 @@ class SgxZmq:
         params['n'] = self.n
         params['t'] = self.t
         params['ind'] = idx
-        response = self.__send_request("complaintResponse", params)
+        response = self.__send_request('complaintResponse', params)
         return ComplaintResponse(
             share=response['share*G2'],
             dh_key=response['dhKey'],
-            verification_vector_mult=response['verificationVectorMult']
+            verification_vector_mult=response['verificationVectorMult'],
         )
 
     def mult_g2(self, to_mult):
         params = dict()
         params['x'] = to_mult
-        response = self.__send_request("multG2", params)
+        response = self.__send_request('multG2', params)
         return response['x*G2']
 
     def import_bls_private_key(self, key_share_name, key_share):
         params = dict()
         params['keyShareName'] = key_share_name
         params['keyShare'] = key_share
-        response = self.__send_request("importBLSKeyShare", params)
+        response = self.__send_request('importBLSKeyShare', params)
         encrypted_key = response['encryptedKeyShare']
         return encrypted_key
 
     def is_poly_exists(self, poly_name):
         params = dict()
         params['polyName'] = poly_name
-        response = self.__send_request("isPolyExists", params)
-        is_exists = response["IsExist"]
+        response = self.__send_request('isPolyExists', params)
+        is_exists = response['IsExist']
         return is_exists
 
     def delete_bls_key(self, bls_key_name):
         params = dict()
         params['blsKeyName'] = bls_key_name
-        response = self.__send_request("deleteBlsKey", params)
-        result = response["deleted"]
+        response = self.__send_request('deleteBlsKey', params)
+        result = response['deleted']
 
         return result
 
@@ -241,8 +235,8 @@ class SgxZmq:
         params['t'] = self.t
         params['n'] = self.n
         params['publicShares'] = verification_vectors
-        response = self.__send_request("calculateAllBLSPublicKeys", params)
-        result = response["publicKeys"]
+        response = self.__send_request('calculateAllBLSPublicKeys', params)
+        result = response['publicKeys']
 
         return result
 
@@ -252,24 +246,24 @@ class SgxZmq:
         params['messageHash'] = message_hash
         params['t'] = self.t
         params['n'] = self.n
-        response = self.__send_request("blsSignMessageHash", params)
-        result = response["signatureShare"]
+        response = self.__send_request('blsSignMessageHash', params)
+        result = response['signatureShare']
 
         return result
 
     def __send_request(self, method, params=None):
         if not params:
             params = dict()
-        params["type"] = self.method_to_type[method]
+        params['type'] = self.method_to_type[method]
         if self.path_to_cert:
-            params["cert"] = self.cert
+            params['cert'] = self.cert
             msgSig = self.__sign_msg(params)
-            params["msgSig"] = msgSig
+            params['msgSig'] = msgSig
         msg = json.dumps(params, separators=(',', ':'))
         p_id = os.getpid()
         if not self.sockets.get(p_id):
             socket_p_id = self.ctx.socket(zmq.DEALER)
-            socket_p_id.setsockopt_string(zmq.IDENTITY, "135:14603077656239261618")
+            socket_p_id.setsockopt_string(zmq.IDENTITY, '135:14603077656239261618')
             socket_p_id.setsockopt(zmq.LINGER, 0)
             socket_p_id.setsockopt(zmq.SNDTIMEO, SGX_ZMQ_RESPONSE_TIMEOUT_MS)
             socket_p_id.setsockopt(zmq.RCVTIMEO, SGX_ZMQ_RESPONSE_TIMEOUT_MS)
@@ -290,22 +284,23 @@ class SgxZmq:
         if not response_str:
             raise SgxZmqUnreachableError('Max retries exceeded for sgx connection')
         response = json.loads(response_str)
-        if (response.get('errorMessage') is not None and
-                len(response.get('errorMessage'))) or response['status']:
+        if (
+            response.get('errorMessage') is not None and len(response.get('errorMessage'))
+        ) or response['status']:
             raise SgxZmqServerError(response['errorMessage'])
         return response
 
     def __sign_msg(self, to_sign):
         msg = json.dumps(to_sign, separators=(',', ':'))
-        msg = msg.replace(" ", "")
+        msg = msg.replace(' ', '')
         key_path = os.path.join(self.path_to_cert, KEY_FILENAME)
-        with open(key_path, "r") as key_file:
-            private_key = key_file.read()
-        key = EVP.load_key_string(private_key.encode())
-        key.reset_context(md='sha256')
-        key.sign_init()
-        key.sign_update(msg.encode())
-        return binascii.hexlify(key.sign_final()).decode()
+        with open(key_path, 'rb') as key_file:
+            private_key_bytes = key_file.read()
+        private_key = load_pem_private_key(
+            private_key_bytes, password=None, backend=default_backend()
+        )
+        signature = private_key.sign(msg.encode(), ec.ECDSA(hashes.SHA256()))
+        return binascii.hexlify(signature).decode()
 
     def __read_cert(self):
         crt_path = os.path.join(self.path_to_cert, CRT_FILENAME)
@@ -314,24 +309,24 @@ class SgxZmq:
 
     def __init_method_types(self):
         self.method_to_type = dict()
-        self.method_to_type["ecdsaSignMessageHash"] = "ECDSASignReq"
-        self.method_to_type["generateECDSAKey"] = "generateECDSAReq"
-        self.method_to_type["getPublicECDSAKey"] = "getPublicECDSAReq"
-        self.method_to_type["generateDKGPoly"] = "generateDKGPolyReq"
-        self.method_to_type["getVerificationVector"] = "getVerificationVectorReq"
-        self.method_to_type["getSecretShare"] = "getSecretShareReq"
-        self.method_to_type["getServerStatus"] = "getServerStatusReq"
-        self.method_to_type["getServerVersion"] = "getServerVersionReq"
-        self.method_to_type["dkgVerification"] = "dkgVerificationReq"
-        self.method_to_type["createBLSPrivateKey"] = "createBLSPrivateReq"
-        self.method_to_type["getBLSPublicKeyShare"] = "getBLSPublicReq"
-        self.method_to_type["complaintResponse"] = "complaintResponseReq"
-        self.method_to_type["importBLSKeyShare"] = "importBLSReq"
-        self.method_to_type["isPolyExists"] = "isPolyExistsReq"
-        self.method_to_type["deleteBlsKey"] = "deleteBLSKeyReq"
-        self.method_to_type["calculateAllBLSPublicKeys"] = "getAllBLSPublicReq"
-        self.method_to_type["blsSignMessageHash"] = "BLSSignReq"
-        self.method_to_type["multG2"] = "multG2Req"
+        self.method_to_type['ecdsaSignMessageHash'] = 'ECDSASignReq'
+        self.method_to_type['generateECDSAKey'] = 'generateECDSAReq'
+        self.method_to_type['getPublicECDSAKey'] = 'getPublicECDSAReq'
+        self.method_to_type['generateDKGPoly'] = 'generateDKGPolyReq'
+        self.method_to_type['getVerificationVector'] = 'getVerificationVectorReq'
+        self.method_to_type['getSecretShare'] = 'getSecretShareReq'
+        self.method_to_type['getServerStatus'] = 'getServerStatusReq'
+        self.method_to_type['getServerVersion'] = 'getServerVersionReq'
+        self.method_to_type['dkgVerification'] = 'dkgVerificationReq'
+        self.method_to_type['createBLSPrivateKey'] = 'createBLSPrivateReq'
+        self.method_to_type['getBLSPublicKeyShare'] = 'getBLSPublicReq'
+        self.method_to_type['complaintResponse'] = 'complaintResponseReq'
+        self.method_to_type['importBLSKeyShare'] = 'importBLSReq'
+        self.method_to_type['isPolyExists'] = 'isPolyExistsReq'
+        self.method_to_type['deleteBlsKey'] = 'deleteBLSKeyReq'
+        self.method_to_type['calculateAllBLSPublicKeys'] = 'getAllBLSPublicReq'
+        self.method_to_type['blsSignMessageHash'] = 'BLSSignReq'
+        self.method_to_type['multG2'] = 'multG2Req'
 
 
 def get_provider(endpoint):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,7 +10,7 @@ from eth_account.messages import defunct_hash_message, encode_defunct
 from dotenv import load_dotenv
 from eth_keys import keys
 from hexbytes import HexBytes
-from telnetlib import Telnet
+import socket
 from web3 import Web3
 
 
@@ -99,8 +99,8 @@ def generate_tx(web3, tx_type=None, no_fee=False):
 
 def test_server_connection():
     parsed_url = urllib.parse.urlparse(SGX_URL)
-    with Telnet(parsed_url.hostname, parsed_url.port, timeout=5) as tn:
-        tn.msg('Test')
+    with socket.create_connection((parsed_url.hostname, parsed_url.port), timeout=5) as s:
+        s.sendall(b'\n')
 
 
 def test_sign_and_send(sgx, account, w3):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -163,7 +163,7 @@ def test_sign_message(sgx, account, w3):
     signed_message = sgx.sign_hash(message, key, None)
     assert signed_message.message_hash == HexBytes(message)
     assert len(signed_message.signature) > 2
-    assert type(signed_message.signature) == HexBytes
+    assert type(signed_message.signature) is HexBytes
 
     recover_account = w3.eth.account.recover_message(
         encode_defunct(transaction_hash), signature=signed_message.signature
@@ -198,7 +198,7 @@ def test_import_ecdsa(sgx, w3):
     signed_message = sgx.sign_hash(message, ecdsa_key_name, None)
     assert signed_message.message_hash == HexBytes(message)
     assert len(signed_message.signature) > 2
-    assert type(signed_message.signature) == HexBytes
+    assert type(signed_message.signature) is HexBytes
 
     recover_account = w3.eth.account.recover_message(
         encode_defunct(transaction_hash), signature=signed_message.signature


### PR DESCRIPTION
This pull request modernizes the codebase by upgrading Python support to 3.13, switching the linter from flake8 to ruff, and updating several dependencies for improved security and compatibility. It also refactors the `sgx_zmq.py` module to replace the deprecated `M2Crypto` library with the more widely used `cryptography` library for key management and signing operations, and standardizes string formatting throughout the code. These changes enhance maintainability, security, and future-proof the project.

**Dependency and Environment Upgrades:**

* Upgraded Python version requirement and CI setup from 3.11 to 3.13 in `setup.py` and GitHub workflow files (`test.yml`, `publish.yml`). [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L30-R35) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L20-R23) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L21-R24) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L57-R60)
* Updated package dependencies: replaced `M2Crypto` with `cryptography`, and bumped versions for `pyzmq` and `pem`. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L30-R35) [[2]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L32-R38)

**Linting and Code Quality:**

* Switched linter from flake8 to ruff in both development dependencies and CI workflows; removed `.flake8` config file and related workflow steps. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L8-R8) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L33-R35) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L70-L72) [[4]](diffhunk://#diff-6951dbb399883798a226c1fb496fdb4183b1ab48865e75eddecf6ceb6cf46442L1-L3)

**Security and Cryptography Refactoring:**

* Refactored `sgx_zmq.py` to use the `cryptography` library for key loading and signing, replacing all usages of `M2Crypto` and updating related logic. [[1]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L32-R38) [[2]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L293-R306)
* Standardized string formatting to use single quotes throughout `sgx_zmq.py` and updated method type mappings. [[1]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L32-R38) [[2]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L110-R117) [[3]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L134-R127) [[4]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L145-R138) [[5]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L156-R158) [[6]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L176-R169) [[7]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L188-R187) [[8]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L203-R228) [[9]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L244-R238) [[10]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L255-R265) [[11]](diffhunk://#diff-041ee48297583fe73658e0def6cc13ee55d2e9d0703822bfee40c8813663c426L317-R332)

**Testing Consistency:**

* Minor test updates to use `is` instead of `==` for type checks in `tests/test_core.py`. [[1]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L166-R166) [[2]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L201-R201)