### PR TITLE
Add new dkg api calls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           ruff check sgx/ tests/
       - name: Run containers
         run: |
-          export SGX_WALLET_TAG=1.10.1-develop.4
+          export SGX_WALLET_TAG=ddbc77fac05f7c1608232853334d78004f5e06b4
           bash scripts/run_sgx_simulator.sh
           mkdir $CERT_PATH
           docker run -d -p 8545:8545 --name ganache trufflesuite/ganache:beta --account="0x${{ secrets.ETH_PRIVATE_KEY }},100000000000000000000000000" -l 80000000 -b 0.01
@@ -71,7 +71,7 @@ jobs:
           pip install -e .[dev]
       - name: Run containers
         run: |
-          export SGX_WALLET_TAG=1.10.1-develop.4
+          export SGX_WALLET_TAG=ddbc77fac05f7c1608232853334d78004f5e06b4
           bash scripts/run_sgx_simulator.sh
           mkdir $CERT_PATH
           sleep 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           ruff check sgx/ tests/
       - name: Run containers
         run: |
-          export SGX_WALLET_TAG=ddbc77fac05f7c1608232853334d78004f5e06b4
+          export SGX_WALLET_TAG=1.10.2-develop.11
           bash scripts/run_sgx_simulator.sh
           mkdir $CERT_PATH
           docker run -d -p 8545:8545 --name ganache trufflesuite/ganache:beta --account="0x${{ secrets.ETH_PRIVATE_KEY }},100000000000000000000000000" -l 80000000 -b 0.01
@@ -71,7 +71,7 @@ jobs:
           pip install -e .[dev]
       - name: Run containers
         run: |
-          export SGX_WALLET_TAG=ddbc77fac05f7c1608232853334d78004f5e06b4
+          export SGX_WALLET_TAG=1.10.2-develop.11
           bash scripts/run_sgx_simulator.sh
           mkdir $CERT_PATH
           sleep 60

--- a/README.md
+++ b/README.md
@@ -47,9 +47,13 @@ pip install -e .[dev]
 
 Create a `.env` file in source directory, like the following:
 ```bash
+# SGXWallet listening point (1026 uses https w/ certificates)
 SERVER=https://127.0.0.1:1026
+# path where you want tests to store the auto-generated certificates
 CERT_PATH=.
+# private key for the funded test account used by transaction tests
 ETH_PRIVATE_KEY=
+# Ethereum JSON-RPC endpoint used by transaction tests
 GETH=
 ```
 You may alter the fields as needed.

--- a/sgx/sgx.py
+++ b/sgx/sgx.py
@@ -123,6 +123,11 @@ class SgxClient:
     def generate_dkg_poly(self, poly_name):
         return self.sgx_rpc_server.generate_dkg_poly(poly_name, self.t)
 
+    def generate_dkg_poly_v3(self, poly_name, previous_bls_private_key_name):
+        return self.sgx_rpc_server.generate_dkg_poly_v3(
+            poly_name, previous_bls_private_key_name, self.t
+        )
+
     def get_verification_vector(self, poly_name):
         return self.sgx_rpc_server.get_verification_vector(poly_name, self.n, self.t)
 
@@ -162,6 +167,13 @@ class SgxClient:
     def create_bls_private_key_v2(self, poly_name, bls_key_name, eth_key_name, secret_shares):
         return self.sgx_rpc_server.create_bls_private_key_v2(
             poly_name, bls_key_name, eth_key_name, secret_shares, self.n, self.t
+        )
+
+    def create_bls_private_key_v3(
+        self, poly_name, bls_key_name, eth_key_name, secret_contributions
+    ):
+        return self.sgx_rpc_server.create_bls_private_key_v3(
+            poly_name, bls_key_name, eth_key_name, secret_contributions, self.n, self.t
         )
 
     def get_bls_public_key(self, bls_key_name):

--- a/sgx/sgx_rpc_handler.py
+++ b/sgx/sgx_rpc_handler.py
@@ -83,6 +83,19 @@ class SgxRPCHandler:
         else:
             return DkgPolyStatus.FAIL
 
+    def generate_dkg_poly_v3(self, poly_name, previous_bls_private_key_name, t):
+        if self.is_poly_exist(poly_name):
+            return DkgPolyStatus.PREEXISTING
+        params = dict()
+        params['polyName'] = poly_name
+        params['previousBLSPrivateKeyName'] = previous_bls_private_key_name
+        params['t'] = t
+        response = self.__send_request("generateDKGPoly", params)
+        if response['result']['status'] == 0:
+            return DkgPolyStatus.NEW_GENERATED
+        else:
+            return DkgPolyStatus.FAIL
+
     def get_verification_vector(self, poly_name, n, t):
         params = dict()
         params['polyName'] = poly_name
@@ -164,6 +177,20 @@ class SgxRPCHandler:
         params['n'] = n
         params['t'] = t
         response = self.__send_request("createBLSPrivateKeyV2", params)
+        return response['result']['status'] == 0
+
+    def create_bls_private_key_v3(self, poly_name, bls_key_name, eth_key_name, secret_contributions, n, t):
+        params = dict()
+        # polyName is optional in V3 - new nodes joining the network do not pass it
+        if poly_name:
+            params['polyName'] = poly_name
+
+        params['blsKeyName'] = bls_key_name
+        params['ethKeyName'] = eth_key_name
+        params['secretContributions'] = secret_contributions
+        params['n'] = n
+        params['t'] = t
+        response = self.__send_request("createBLSPrivateKeyV3", params)
         return response['result']['status'] == 0
 
     def get_bls_public_key(self, bls_key_name):

--- a/sgx/sgx_zmq.py
+++ b/sgx/sgx_zmq.py
@@ -130,6 +130,19 @@ class SgxZmq:
         else:
             return DkgPolyStatus.FAIL
 
+    def generate_dkg_poly_v3(self, poly_name, previous_bls_private_key_name):
+        if self.is_poly_exists(poly_name):
+            return DkgPolyStatus.PREEXISTING
+        params = dict()
+        params['polyName'] = poly_name
+        params['previousBLSPrivateKeyName'] = previous_bls_private_key_name
+        params['t'] = self.t
+        response = self.__send_request('generateDKGPoly', params)
+        if response['status'] == 0:
+            return DkgPolyStatus.NEW_GENERATED
+        else:
+            return DkgPolyStatus.FAIL
+
     def get_verification_vector(self, poly_name):
         params = dict()
         params['polyName'] = poly_name
@@ -179,6 +192,22 @@ class SgxZmq:
         params['n'] = self.n
         params['t'] = self.t
         response = self.__send_request('createBLSPrivateKey', params)
+        return response['status'] == 0
+
+    def create_bls_private_key_v3(
+        self, poly_name, bls_key_name, eth_key_name, secret_contributions
+    ):
+        params = dict()
+        # polyName is optional in V3 - new nodes joining the network do not pass it
+        if poly_name:
+            params['polyName'] = poly_name
+
+        params['blsKeyName'] = bls_key_name
+        params['ethKeyName'] = eth_key_name
+        params['secretContributions'] = secret_contributions
+        params['n'] = self.n
+        params['t'] = self.t
+        response = self.__send_request('createBLSPrivateKeyV3', params)
         return response['status'] == 0
 
     def get_bls_public_key(self, bls_key_name):
@@ -322,6 +351,7 @@ class SgxZmq:
         self.method_to_type['getServerVersion'] = 'getServerVersionReq'
         self.method_to_type['dkgVerification'] = 'dkgVerificationReq'
         self.method_to_type['createBLSPrivateKey'] = 'createBLSPrivateReq'
+        self.method_to_type['createBLSPrivateKeyV3'] = 'createBLSPrivateV3Req'
         self.method_to_type['getBLSPublicKeyShare'] = 'getBLSPublicReq'
         self.method_to_type['complaintResponse'] = 'complaintResponseReq'
         self.method_to_type['importBLSKeyShare'] = 'importBLSReq'

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -12,6 +12,13 @@ import hashlib
 
 load_dotenv()
 
+DKG_TEST_SLEEP_SECONDS = float(os.getenv('DKG_TEST_SLEEP_SECONDS', '0.1'))
+
+
+def dkg_sleep():
+    if DKG_TEST_SLEEP_SECONDS > 0:
+        sleep(DKG_TEST_SLEEP_SECONDS)
+
 
 def bxor(b1, b2):
     parts = []
@@ -34,6 +41,162 @@ def convert_g2_point_to_hex(data):
             temp = '0' + temp
         data_hexed += temp
     return data_hexed
+
+
+def get_sgx_client(n, t, with_zmq=False):
+    if not with_zmq:
+        return SgxClient(os.environ['SERVER'], path_to_cert=os.environ.get('CERT_PATH'), n=n, t=t)
+    return SgxClient(
+        os.environ['SERVER'], path_to_cert=os.environ.get('CERT_PATH'), n=n, t=t, zmq=True
+    ).zmq
+
+
+def get_poly_name(node_id, dkg_id):
+    return (
+        "POLY:SCHAIN_ID:"
+        f"{str(0)}"
+        ":NODE_ID:"
+        f"{str(node_id)}"
+        ":DKG_ID:"
+        f"{str(dkg_id)}"
+    )
+
+
+def get_bls_key_name(node_id, dkg_id):
+    return (
+        "BLS_KEY:SCHAIN_ID:"
+        f"{str(0)}"
+        ":NODE_ID:"
+        f"{str(node_id)}"
+        ":DKG_ID:"
+        f"{str(dkg_id)}"
+    )
+
+
+def hex_verification_vectors(verification_vectors):
+    hexed_vv = []
+    for vv in verification_vectors:
+        cur_hexed = ""
+        for elem in vv:
+            cur_hexed += convert_g2_point_to_hex(elem)
+        hexed_vv.append(cur_hexed)
+    return hexed_vv
+
+
+def assert_bls_signature(sgx, bls_key_name):
+    message = secrets.token_hex(32)
+    signature_share = sgx.bls_sign(bls_key_name, message)
+    splitted_signature = signature_share.split(':')
+    assert len(splitted_signature) == 4
+
+    assert len(splitted_signature[0]) > 0
+    assert len(splitted_signature[0]) < 78
+
+    assert len(splitted_signature[1]) > 0
+    assert len(splitted_signature[1]) < 78
+
+    assert len(splitted_signature[2]) > 0
+    assert len(splitted_signature[2]) < 78
+
+    assert int(splitted_signature[3]) < 1000
+
+
+def assert_new_dkg_poly(response, node_id):
+    if response.name == 'FAIL':
+        raise TypeError("failed generate dkg poly for " + str(node_id))
+    assert response.name == 'NEW_GENERATED'
+
+
+def perform_dkg_v3(t=3, n=4, with_zmq=False):
+    initial_dkg = perform_dkg(t, n, with_0x=True, with_v2=not with_zmq, with_zmq=with_zmq)
+    sgx = initial_dkg['sgx']
+
+    active_node_ids = [0, 1, 2]
+    joining_node_id = 3
+    new_node_key = sgx.generate_key()
+
+    public_keys = [
+        initial_dkg['public_keys'][0],
+        initial_dkg['public_keys'][1],
+        initial_dkg['public_keys'][2],
+        new_node_key.public_key,
+    ]
+    key_names = [
+        initial_dkg['key_names'][0],
+        initial_dkg['key_names'][1],
+        initial_dkg['key_names'][2],
+        new_node_key.name,
+    ]
+    dkg_sleep()
+
+    random_dkg_id = random.randint(0, 10**50)
+
+    active_poly_names = []
+    for node_id in active_node_ids:
+        poly_name = get_poly_name(node_id, random_dkg_id)
+        response = sgx.generate_dkg_poly_v3(poly_name, initial_dkg['bls_key_names'][node_id])
+        assert_new_dkg_poly(response, node_id)
+        active_poly_names.append(poly_name)
+        dkg_sleep()
+
+    verification_vectors = []
+    for poly_name in active_poly_names:
+        verification_vectors.append(sgx.get_verification_vector(poly_name))
+        dkg_sleep()
+
+    hexed_vv = hex_verification_vectors(verification_vectors)
+
+    secret_key_contributions = []
+    for poly_name in active_poly_names:
+        if with_zmq:
+            secret_key_contributions.append(sgx.get_secret_key_contribution(poly_name, public_keys))
+        else:
+            secret_key_contributions.append(
+                sgx.get_secret_key_contribution_v2(poly_name, public_keys)
+            )
+        dkg_sleep()
+
+    for i in range(n):
+        for j in range(len(active_node_ids)):
+            if with_zmq:
+                assert sgx.verify_secret_share(
+                    hexed_vv[j],
+                    key_names[i],
+                    secret_key_contributions[j][192*i:192*(i + 1)],
+                    i,
+                )
+            else:
+                assert sgx.verify_secret_share_v2(
+                    hexed_vv[j],
+                    key_names[i],
+                    secret_key_contributions[j][192*i:192*(i + 1)],
+                    i,
+                )
+            dkg_sleep()
+
+    for i in range(n):
+        poly_name = active_poly_names[i] if i in active_node_ids else None
+        if i == joining_node_id:
+            assert poly_name is None
+        bls_key_name = get_bls_key_name(i, random_dkg_id)
+        assert sgx.create_bls_private_key_v3(
+            poly_name,
+            bls_key_name,
+            key_names[i],
+            [
+                {
+                    'contributorIndex': active_node_ids[j],
+                    'secretShare': secret_key_contributions[j][192*i:192*(i + 1)],
+                }
+                for j in range(len(active_node_ids))
+            ],
+        )
+
+        public_key = sgx.get_bls_public_key(bls_key_name)
+        assert len(public_key) == 4
+        assert all(len(point) > 0 for point in public_key)
+        assert_bls_signature(sgx, bls_key_name)
+        dkg_sleep()
 
 
 def perform_complaint(sgx, t, poly_name, public_key, corrupted_secret_key_contribution):
@@ -59,14 +222,10 @@ def perform_complaint(sgx, t, poly_name, public_key, corrupted_secret_key_contri
 
 
 def perform_dkg(t, n, with_0x=True, with_v2=True, with_complaint=False, with_zmq=False):
-    sgx = None
-    if not with_zmq:
-        sgx = SgxClient(os.environ['SERVER'], path_to_cert=os.environ.get('CERT_PATH'), n=n, t=t)
-    else:
-        sgx = SgxClient(os.environ['SERVER'], path_to_cert=os.environ.get('CERT_PATH'),
-                        n=n, t=t, zmq=True).zmq
+    sgx = get_sgx_client(n, t, with_zmq=with_zmq)
 
     public_keys = []
+    generated_public_keys = []
     key_name = []
 
     random_dkg_id = random.randint(0, 10**50)
@@ -77,55 +236,27 @@ def perform_dkg(t, n, with_0x=True, with_v2=True, with_complaint=False, with_zmq
             public_keys.append(generated_key.public_key)
         else:
             public_keys.append(generated_key.public_key[2:])
+        generated_public_keys.append(generated_key.public_key)
         key_name.append(generated_key.name)
-        sleep(1)
+        dkg_sleep()
 
     for i in range(n):
-        poly_name = (
-            "POLY:SCHAIN_ID:"
-            f"{str(0)}"
-            ":NODE_ID:"
-            f"{str(i)}"
-            ":DKG_ID:"
-            f"{str(random_dkg_id)}"
-        )
-        from sgx.sgx_rpc_handler import DkgPolyStatus
+        poly_name = get_poly_name(i, random_dkg_id)
         response = sgx.generate_dkg_poly(poly_name)
-        if response == DkgPolyStatus.FAIL:
-            raise TypeError("failed generate dkg poly for " + str(i))
-        sleep(5)
+        assert_new_dkg_poly(response, i)
+        dkg_sleep()
 
     verification_vector = []
     for i in range(n):
-        poly_name = (
-            "POLY:SCHAIN_ID:"
-            f"{str(0)}"
-            ":NODE_ID:"
-            f"{str(i)}"
-            ":DKG_ID:"
-            f"{str(random_dkg_id)}"
-        )
+        poly_name = get_poly_name(i, random_dkg_id)
         verification_vector.append(sgx.get_verification_vector(poly_name))
-        sleep(5)
+        dkg_sleep()
 
-    hexed_vv = []
-
-    for vv in verification_vector:
-        cur_hexed = ""
-        for elem in vv:
-            cur_hexed += convert_g2_point_to_hex(elem)
-        hexed_vv.append(cur_hexed)
+    hexed_vv = hex_verification_vectors(verification_vector)
 
     secret_key_contribution = []
     for i in range(n):
-        poly_name = (
-            "POLY:SCHAIN_ID:"
-            f"{str(0)}"
-            ":NODE_ID:"
-            f"{str(i)}"
-            ":DKG_ID:"
-            f"{str(random_dkg_id)}"
-        )
+        poly_name = get_poly_name(i, random_dkg_id)
 
         if with_v2:
             secret_key_contribution.append(
@@ -134,7 +265,7 @@ def perform_dkg(t, n, with_0x=True, with_v2=True, with_complaint=False, with_zmq
             print("KEYS", public_keys)
             secret_key_contribution.append(
                 sgx.get_secret_key_contribution(poly_name, public_keys))
-        sleep(5)
+        dkg_sleep()
 
     if not with_complaint:
         for i in range(n):
@@ -145,34 +276,21 @@ def perform_dkg(t, n, with_0x=True, with_v2=True, with_complaint=False, with_zmq
                             key_name[i],
                             secret_key_contribution[j][192*i:192*(i + 1)], i):
                         raise ValueError(f'{i} failed to verify {j}')
-                    sleep(5)
+                    dkg_sleep()
                 else:
                     if not sgx.verify_secret_share(
                             hexed_vv[j],
                             key_name[i],
                             secret_key_contribution[j][192*i:192*(i + 1)], i):
                         raise ValueError(f'{i} failed to verify {j}')
-                    sleep(5)
+                    dkg_sleep()
 
-        public_keys = sgx.calculate_all_bls_public_keys(hexed_vv)
+        calculated_bls_public_keys = sgx.calculate_all_bls_public_keys(hexed_vv)
+        bls_key_names = []
 
         for i in range(n):
-            poly_name = (
-                "POLY:SCHAIN_ID:"
-                f"{str(0)}"
-                ":NODE_ID:"
-                f"{str(i)}"
-                ":DKG_ID:"
-                f"{str(random_dkg_id)}"
-            )
-            bls_key_name = (
-                "BLS_KEY:SCHAIN_ID:"
-                f"{str(0)}"
-                ":NODE_ID:"
-                f"{str(i)}"
-                ":DKG_ID:"
-                f"{str(random_dkg_id)}"
-            )
+            poly_name = get_poly_name(i, random_dkg_id)
+            bls_key_name = get_bls_key_name(i, random_dkg_id)
 
             if with_v2:
                 sgx.create_bls_private_key_v2(
@@ -186,29 +304,21 @@ def perform_dkg(t, n, with_0x=True, with_v2=True, with_complaint=False, with_zmq
                     bls_key_name,
                     key_name[i],
                     "".join(secret_key_contribution[j][192*i:192*(i + 1)] for j in range(n)))
+            bls_key_names.append(bls_key_name)
 
             public_key = sgx.get_bls_public_key(bls_key_name)
 
-            assert ":".join(public_key) == public_keys[i]
+            assert ":".join(public_key) == calculated_bls_public_keys[i]
 
-            message = secrets.token_hex(32)
+            assert_bls_signature(sgx, bls_key_name)
+            dkg_sleep()
 
-            signature_share = sgx.bls_sign(bls_key_name, message)
-            splitted_signature = signature_share.split(':')
-            assert len(splitted_signature) == 4
-
-            assert len(splitted_signature[0]) > 0
-            assert len(splitted_signature[0]) < 78
-
-            assert len(splitted_signature[1]) > 0
-            assert len(splitted_signature[1]) < 78
-
-            assert len(splitted_signature[2]) > 0
-            assert len(splitted_signature[2]) < 78
-
-            assert int(splitted_signature[3]) < 1000
-
-            sleep(5)
+        return {
+            'sgx': sgx,
+            'public_keys': generated_public_keys,
+            'key_names': key_name,
+            'bls_key_names': bls_key_names,
+        }
     else:
         corrupted_secret_key_contribution = secret_key_contribution[0]
         secret_key_contribution[0] = secret_key_contribution[1]
@@ -237,16 +347,9 @@ def perform_dkg(t, n, with_0x=True, with_v2=True, with_complaint=False, with_zmq
                                 hexed_vv[j],
                                 key_name[i],
                                 secret_key_contribution[j][192*i:192*(i + 1)], i)
-                sleep(5)
+                dkg_sleep()
 
-        poly_name = (
-                "POLY:SCHAIN_ID:"
-                f"{str(0)}"
-                ":NODE_ID:"
-                f"{str(0)}"
-                ":DKG_ID:"
-                f"{str(random_dkg_id)}"
-            )
+        poly_name = get_poly_name(0, random_dkg_id)
         perform_complaint(
                         sgx,
                         t,
@@ -407,6 +510,12 @@ def test_old_dkg():
 def test_dkg_zmq():
     perform_dkg(2, 2, with_0x=True, with_v2=False, with_zmq=True)
     print("TEST DKG WITH ZMQ PASSED")
+
+
+def test_dkg_v3():
+    perform_dkg_v3(3, 4)
+    perform_dkg_v3(3, 4, with_zmq=True)
+    print("TEST DKG V3 PASSED")
 
 
 def test_dkg_complaint():


### PR DESCRIPTION
## Description

Adds DKG v3 rotation test coverage and client support.

## Changes

- Added `SgxClient` wrappers for:
  - `generate_dkg_poly_v3`
  - `create_bls_private_key_v3`
- Added ZMQ support for DKG v3 create-BLS-key requests.
- Added `test_dkg_v3`, covering:
  - initial 4-node DKG bootstrap
  - 3 active old nodes generating v3 polynomials
  - 1 old node rotating out
  - 1 new node joining
  - v3 BLS key creation for all nodes
- Reused the existing `perform_dkg` helper to return generated DKG state for v3 setup.
- Reduced DKG test wait time via configurable `DKG_TEST_SLEEP_SECONDS`.
- Updated README test env comments.

## Notes

This depends on SGX wallet support for the DKG v3 API. workflow file was updated to point to the new (unmerged) sgxwallet version with dkg v3 support. This will be reverted before merging

Fixes #189 